### PR TITLE
【React理解度テスト】書籍管理アプリの修正

### DIFF
--- a/my-book-register/src/App.css
+++ b/my-book-register/src/App.css
@@ -7,6 +7,12 @@
   background-color: antiquewhite;
 }
 
+/* 第四問 ボタンホバー時に押せそうな見た目になるよう変更 */
+.button:hover{
+  opacity: 0.8;
+  cursor: pointer;
+}
+
 .label {
   font-weight: bold;
 }

--- a/my-book-register/src/App.css
+++ b/my-book-register/src/App.css
@@ -13,6 +13,7 @@
 
 .input {
   height: 25px;
+  margin: 0 16px;
 }
 
 .label-input {
@@ -25,4 +26,11 @@
 
 .filterable-book-table {
   display: flex;
+  flex-wrap: wrap;
+}
+
+table{
+  width: 100%;
+  text-align: center;
+  margin-top: 16px;
 }

--- a/my-book-register/src/App.tsx
+++ b/my-book-register/src/App.tsx
@@ -44,11 +44,21 @@ function App() {
         onClickDelete={(id) => {
           {
             /* 第2問：貸出 or 返却 or 削除の処理を追加 */
+            setBooks(books.filter((book) => book.id !== id));
           }
         }}
         onClickLendingSwitch={(id) => {
           {
             /* 第2問：貸出 or 返却 or 削除の処理を追加 */
+            setBooks(
+              books.map((book) => {
+                if (book.id === id) {
+                  return { ...book, isOnLoan: !book.isOnLoan };
+                } else {
+                  return book;
+                }
+              }),
+            );
           }
         }}
       />

--- a/my-book-register/src/App.tsx
+++ b/my-book-register/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import './App.css';
 import FilterableBookTable from './components/filterableBookTable';
 import { BookItemModel } from './models';
+import BookRegister from './components/bookRegister';
 
 function App() {
   const [isbn, setIsbn] = useState('');
@@ -30,37 +31,30 @@ function App() {
         ...postedItem,
       },
     ]);
-  }
+  };
 
   return (
     <div className="App">
       {/* 第1問：コンポーネントに分割 ↓ ↓ ↓ ↓ ↓ */}
-      <div className="book-register">
-        <div className="label-input">
-          <label className="label">
-            ISBNコード
-          </label>
-          <input className="input" placeholder="入力してください" value={isbn} onChange={(e) => setIsbn(e.target.value)}></input>
-        </div>
-        <button className="button" onClick={handleClickButton}>
-          書籍登録
-        </button>
-      </div>
+      <BookRegister isbn={isbn} setIsbn={setIsbn} handleClickButton={handleClickButton} />
       {/* 第1問：コンポーネントに分割 ↑ ↑ ↑ ↑ ↑ ↑ */}
       <hr />
       <FilterableBookTable
         books={books}
         onClickDelete={(id) => {
-            {/* 第2問：貸出 or 返却 or 削除の処理を追加 */}            
+          {
+            /* 第2問：貸出 or 返却 or 削除の処理を追加 */
           }
-        }
+        }}
         onClickLendingSwitch={(id) => {
-            {/* 第2問：貸出 or 返却 or 削除の処理を追加 */}            
+          {
+            /* 第2問：貸出 or 返却 or 削除の処理を追加 */
           }
-        }
+        }}
       />
     </div>
   );
 }
 
 export default App;
+

--- a/my-book-register/src/App.tsx
+++ b/my-book-register/src/App.tsx
@@ -12,6 +12,8 @@ function App() {
     fetch(`https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}`)
       .then((response) => response.json())
       .then((data) => {
+        // 第四問 登録ボタンを押して送信したら入力欄をクリアする
+        setIsbn('');
         if (data.totalItems === 0) {
           alert('登録されていない ISBN コードです。');
           return;

--- a/my-book-register/src/App.tsx
+++ b/my-book-register/src/App.tsx
@@ -9,11 +9,14 @@ function App() {
   const [books, setBooks] = useState<BookItemModel[]>([]);
 
   const handleClickButton = (): void => {
+    if (books.some((book) => book.id === isbn)) {
+      alert('登録済みの ISBNコードです。');
+      return;
+    }
     fetch(`https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}`)
       .then((response) => response.json())
       .then((data) => {
         // 第四問 登録ボタンを押して送信したら入力欄をクリアする
-        setIsbn('');
         if (data.totalItems === 0) {
           alert('登録されていない ISBN コードです。');
           return;
@@ -22,6 +25,7 @@ function App() {
           name: data.items[0].volumeInfo.title,
           isOnLoan: false,
         });
+        setIsbn('');
       });
   };
 
@@ -29,7 +33,7 @@ function App() {
     setBooks((prev) => [
       ...prev,
       {
-        id: prev.length.toString(),
+        id: isbn,
         ...postedItem,
       },
     ]);

--- a/my-book-register/src/components/bookRegister.tsx
+++ b/my-book-register/src/components/bookRegister.tsx
@@ -1,0 +1,31 @@
+import Button from './button';
+import LabelInput from './labelInput';
+
+interface Props {
+  isbn: string;
+  setIsbn: React.Dispatch<React.SetStateAction<string>>;
+  handleClickButton: () => void;
+}
+
+const BookRegister = ({ isbn, setIsbn, handleClickButton }: Props) => {
+  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    setIsbn(e.target.value);
+  };
+
+  return (
+    <div className="book-register">
+      <LabelInput
+        className="label-input"
+        labelClassName="label"
+        labelValue="ISBNコード"
+        inputValue={isbn}
+        inputPlaceHolder="入力してください"
+        inputClassName="input"
+        handleOnChange={handleOnChange}
+      />
+      <Button value="書籍登録" handleClickButton={handleClickButton} className="button" />
+    </div>
+  );
+};
+
+export default BookRegister;

--- a/my-book-register/src/components/bookRow.tsx
+++ b/my-book-register/src/components/bookRow.tsx
@@ -10,7 +10,7 @@ const BookRow = ({ bookItem, onClickDelete, onClickLendingSwitch }: Props) => {
   return (
     <tr>
       <td>{bookItem.name}</td>
-      <td>{'貸出中 or 利用可能'}</td>
+      <td>{bookItem.isOnLoan ? '貸出中' : '利用可能'}</td>
       <td>
         <button className="button" onClick={() => onClickDelete(bookItem.id)}>
           削除

--- a/my-book-register/src/components/bookRow.tsx
+++ b/my-book-register/src/components/bookRow.tsx
@@ -12,7 +12,8 @@ const BookRow = ({ bookItem, onClickDelete, onClickLendingSwitch }: Props) => {
       <td>{bookItem.name}</td>
       <td>{bookItem.isOnLoan ? '貸出中' : '利用可能'}</td>
       <td>
-        <button className="button" onClick={() => onClickDelete(bookItem.id)}>
+        {/* 第四問 貸し出し中に削除できないように変更 */}
+        <button className="button" onClick={() => onClickDelete(bookItem.id)} disabled={bookItem.isOnLoan}>
           削除
         </button>
         <button className="button" onClick={() => onClickLendingSwitch(bookItem.id)} disabled={bookItem.isOnLoan}>

--- a/my-book-register/src/components/bookRow.tsx
+++ b/my-book-register/src/components/bookRow.tsx
@@ -26,3 +26,4 @@ const BookRow = ({ bookItem, onClickDelete, onClickLendingSwitch }: Props) => {
   );
 };
 export default BookRow;
+

--- a/my-book-register/src/components/bookTable.tsx
+++ b/my-book-register/src/components/bookTable.tsx
@@ -8,11 +8,7 @@ interface Props {
   onClickLendingSwitch: (id: string) => void;
 }
 
-const BookTable = ({
-  bookItems,
-  onClickDelete,
-  onClickLendingSwitch,
-}: Props) => {
+const BookTable = ({ bookItems, onClickDelete, onClickLendingSwitch }: Props) => {
   return (
     <table border={1}>
       <thead>
@@ -22,15 +18,19 @@ const BookTable = ({
           <td>操作</td>
         </tr>
       </thead>
-      {bookItems.map((book) => (
-        <BookRow
-          bookItem={book}
-          onClickDelete={onClickDelete}
-          onClickLendingSwitch={onClickLendingSwitch}
-          key={book.id}
-        />
-      ))}
+      {/* 第四問 tabele直下にtrがあってtbodyがない警告が出ないように修正 */}
+      <tbody>
+        {bookItems.map((book) => (
+          <BookRow
+            bookItem={book}
+            onClickDelete={onClickDelete}
+            onClickLendingSwitch={onClickLendingSwitch}
+            key={book.id}
+          />
+        ))}
+      </tbody>
     </table>
   );
 };
 export default BookTable;
+

--- a/my-book-register/src/components/button.tsx
+++ b/my-book-register/src/components/button.tsx
@@ -1,0 +1,15 @@
+interface Props {
+  className: string;
+  value: string;
+  handleClickButton: () => void;
+}
+
+const Button = ({ className, value, handleClickButton }: Props) => {
+  return (
+    <button className={className} onClick={handleClickButton}>
+      {value}
+    </button>
+  );
+};
+
+export default Button;

--- a/my-book-register/src/components/filterableBookTable.tsx
+++ b/my-book-register/src/components/filterableBookTable.tsx
@@ -12,7 +12,10 @@ interface Props {
 const FilterableBookTable = ({ books, onClickDelete, onClickLendingSwitch }: Props) => {
   const [filterText, setFilterText] = useState('');
 
+  const [isDisplayOnlyAvailable, setIsDisplayOnlyAvailable] = useState(false);
+
   const handleChangeFilterText: ChangeEventHandler<HTMLInputElement> = (e) => setFilterText(e.target.value);
+  const handleChangeIsCheck: ChangeEventHandler<HTMLInputElement> = (e) => setIsDisplayOnlyAvailable(e.target.checked);
 
   return (
     <div className="filterable-book-table">
@@ -26,8 +29,23 @@ const FilterableBookTable = ({ books, onClickDelete, onClickLendingSwitch }: Pro
         handleOnChange={handleChangeFilterText}
       />
 
+      <LabelInput
+        className="label-input"
+        labelClassName="label"
+        labelValue="利用可能のみ表示"
+        inputValue=""
+        inputType="checkbox"
+        inputPlaceHolder=""
+        inputClassName=""
+        handleOnChange={handleChangeIsCheck}
+      />
+
       <BookTable
-        bookItems={books.filter((x) => !filterText || x.name.includes(filterText))}
+        bookItems={books.filter((x) => {
+          const availableFilter = isDisplayOnlyAvailable ? !x.isOnLoan : true;
+          const nameFilter = !filterText || x.name.includes(filterText);
+          return availableFilter && nameFilter;
+        })}
         onClickDelete={onClickDelete}
         onClickLendingSwitch={onClickLendingSwitch}
       />

--- a/my-book-register/src/components/filterableBookTable.tsx
+++ b/my-book-register/src/components/filterableBookTable.tsx
@@ -1,6 +1,7 @@
 import { ChangeEventHandler, useState } from 'react';
 import { BookItemModel } from '../models';
 import BookTable from './bookTable';
+import LabelInput from './labelInput';
 
 interface Props {
   books: BookItemModel[];
@@ -8,28 +9,25 @@ interface Props {
   onClickLendingSwitch: (id: string) => void;
 }
 
-const FilterableBookTable = ({
-  books,
-  onClickDelete,
-  onClickLendingSwitch,
-}: Props) => {
+const FilterableBookTable = ({ books, onClickDelete, onClickLendingSwitch }: Props) => {
   const [filterText, setFilterText] = useState('');
 
-  const handleChangeFilterText: ChangeEventHandler<HTMLInputElement> = (e) =>
-    setFilterText(e.target.value);
+  const handleChangeFilterText: ChangeEventHandler<HTMLInputElement> = (e) => setFilterText(e.target.value);
 
   return (
     <div className="filterable-book-table">
-      <div className="label-input">
-        <label className="label">
-          filter
-        </label>
-        <input className="input" placeholder="入力してください" value={filterText} onChange={handleChangeFilterText}></input>
-      </div>
+      <LabelInput
+        className="label-input"
+        labelClassName="label"
+        labelValue="filter"
+        inputClassName="input"
+        inputPlaceHolder="入力してください"
+        inputValue={filterText}
+        handleOnChange={handleChangeFilterText}
+      />
+
       <BookTable
-        bookItems={books.filter(
-          (x) => !filterText || x.name.includes(filterText),
-        )}
+        bookItems={books.filter((x) => !filterText || x.name.includes(filterText))}
         onClickDelete={onClickDelete}
         onClickLendingSwitch={onClickLendingSwitch}
       />
@@ -37,3 +35,4 @@ const FilterableBookTable = ({
   );
 };
 export default FilterableBookTable;
+

--- a/my-book-register/src/components/input.tsx
+++ b/my-book-register/src/components/input.tsx
@@ -1,12 +1,15 @@
 interface Props {
   value: string;
+  type?: string;
   className: string;
   placeHolder: string;
   handleOnChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-const Input = ({ value, placeHolder, handleOnChange, className }: Props) => {
-  return <input className={className} placeholder={placeHolder} value={value} onChange={handleOnChange}></input>;
+const Input = ({ value, type = 'text', placeHolder, handleOnChange, className }: Props) => {
+  return (
+    <input type={type} className={className} placeholder={placeHolder} value={value} onChange={handleOnChange}></input>
+  );
 };
 
 export default Input;

--- a/my-book-register/src/components/input.tsx
+++ b/my-book-register/src/components/input.tsx
@@ -1,0 +1,12 @@
+interface Props {
+  value: string;
+  className: string;
+  placeHolder: string;
+  handleOnChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const Input = ({ value, placeHolder, handleOnChange, className }: Props) => {
+  return <input className={className} placeholder={placeHolder} value={value} onChange={handleOnChange}></input>;
+};
+
+export default Input;

--- a/my-book-register/src/components/labelInput.tsx
+++ b/my-book-register/src/components/labelInput.tsx
@@ -1,0 +1,35 @@
+import Input from './input';
+
+interface Props {
+  className: string;
+  labelClassName: string;
+  labelValue: string;
+  inputValue: string;
+  inputPlaceHolder: string;
+  inputClassName: string;
+  handleOnChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const LabelInput = ({
+  className,
+  labelClassName,
+  labelValue,
+  inputValue,
+  inputPlaceHolder,
+  inputClassName,
+  handleOnChange,
+}: Props) => {
+  return (
+    <div className={className}>
+      <label className={labelClassName}>{labelValue}</label>
+      <Input
+        value={inputValue}
+        placeHolder={inputPlaceHolder}
+        className={inputClassName}
+        handleOnChange={handleOnChange}
+      />
+    </div>
+  );
+};
+
+export default LabelInput;

--- a/my-book-register/src/components/labelInput.tsx
+++ b/my-book-register/src/components/labelInput.tsx
@@ -5,6 +5,7 @@ interface Props {
   labelClassName: string;
   labelValue: string;
   inputValue: string;
+  inputType?: string;
   inputPlaceHolder: string;
   inputClassName: string;
   handleOnChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -15,19 +16,22 @@ const LabelInput = ({
   labelClassName,
   labelValue,
   inputValue,
+  inputType = 'text',
   inputPlaceHolder,
   inputClassName,
   handleOnChange,
 }: Props) => {
   return (
     <div className={className}>
-      <label className={labelClassName}>{labelValue}</label>
+      {inputType === 'text' && <label className={labelClassName}>{labelValue}</label>}
       <Input
         value={inputValue}
+        type={inputType}
         placeHolder={inputPlaceHolder}
         className={inputClassName}
         handleOnChange={handleOnChange}
       />
+      {inputType !== 'text' && <label className={labelClassName}>{labelValue}</label>}
     </div>
   );
 };

--- a/my-book-register/tsconfig.json
+++ b/my-book-register/tsconfig.json
@@ -23,3 +23,4 @@
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }
+


### PR DESCRIPTION
React理解度テストの解答を作成しました。
各コミットの内容は以下の通りです。
- 第一問：ヘッダーの登録欄をコンポーネントに分割
    -  c8efc6b45c0450380eac65d4c4da3f4b4225ee97
    
- 第二問： 書籍欄の削除、貸出、返却ボタンが動作するように修正
    -  67a47293f8ff29179bcf7fbfa4d255e590a0d237

- 第三問：お手本と同じ見た目になるようにCSSを修正
    -  480167bdae169286784c7865ecbca9c1eed0cfe7

- 第四問：その他の機能追加
    -  ボタンを押せそうな見た目になるよう変更、書籍登録時に入力欄をクリア、貸出中に削除できないよう変更、警告の対応
        -  828b18a7e3831c452128237092323e41462cde29
    - 貸出可能の本のみ表示する チェックボックスの追加
        -  6bba9ac4539f01646cb02971c2a4a286ed948084
    - 登録済みの本を重複して登録できないように変更
        -  6716674bd797a3a3032946be580b1c2bb2f13968

画面イメージ
![タイトルなし](https://github.com/kentem-hi-murota/react-test/assets/168146646/ef468c3f-9f66-4403-84c7-7ebd9d9bec27)
